### PR TITLE
calculate points based on associated transactions

### DIFF
--- a/client/views/checkPoints.js
+++ b/client/views/checkPoints.js
@@ -1,6 +1,8 @@
 Template.checkPoints.helpers({
   'totalPoints': function() {
-    return Meteor.user().profile.points;
+    return Transactions.find({userId: Meteor.userId()}).fetch().reduce(function(sum, transaction) {
+      return sum += transaction.points;
+    }, 0);
   },
   'activities': function() {
     //TODO: currently pulling all transactions, need to limit it by userId. This involves setting a hidden field for userId on autoform?


### PR DESCRIPTION
Currently the `totalPoints` algorithm looks within a user's profile; this change goes straight to the list of transactions to calculate a user's points.
